### PR TITLE
Update userOpHash to use EIP-712 domain separator

### DIFF
--- a/.changeset/sixty-foxes-yell.md
+++ b/.changeset/sixty-foxes-yell.md
@@ -1,0 +1,5 @@
+---
+"@soulwallet/sdk": patch
+---
+
+Refactored getUserOpHash to compute the hash using an EIP-712 domain separator for improved standards compliance. Updated test values to match the new hashing logic and adjusted packUserOp encoding to include a type hash.

--- a/packages/soulwallet-sdk/__tests__/main.test.ts
+++ b/packages/soulwallet-sdk/__tests__/main.test.ts
@@ -301,9 +301,9 @@ describe('SDK', () => {
             signature: '0xb0'
         };
 
-        const entrypointAddress = '0x0000000071727De22E5E9d8BAf0edAc6f37da032';
+        const entrypointAddress = '0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108';
         const chainId = 1;
-        const userOpHash = '0xb52cfcae9bba87f372db89cc6e43d71d53f304be0cbda3db9f28c4d93c37949d';
+        const userOpHash = '0xad630688ac6ecbed27d4f621d4fe816e51eec658f20ae2d84b783b3ca28f00ce';
         {
             const _userOpHash = UserOpUtils.getUserOpHash(packedUserOp, entrypointAddress, chainId);
             expect(_userOpHash).toBe(userOpHash);

--- a/packages/soulwallet-sdk/src/tools/userOpHash.ts
+++ b/packages/soulwallet-sdk/src/tools/userOpHash.ts
@@ -14,17 +14,17 @@ export function packUserOp(packedOp: PackedUserOperation): string {
     const abiCoder = new ethers.AbiCoder();
     return abiCoder.encode(
         [
-            'address', 'uint256', 'bytes32', 'bytes32',
-            'bytes32', 'uint256', 'bytes32', 'bytes32'
+            'bytes32',
+            'address', 'uint256',
+            'bytes32', 'bytes32',
+            'bytes32', 'uint256', 'bytes32',
+            'bytes32'
         ],
         [
-            packedOp.sender,
-            packedOp.nonce,
-            keccak256(packedOp.initCode),
-            keccak256(packedOp.callData),
-            packedOp.accountGasLimits,
-            packedOp.preVerificationGas,
-            packedOp.gasFees,
+            keccak256(ethers.toUtf8Bytes('PackedUserOperation(address sender,uint256 nonce,bytes initCode,bytes callData,bytes32 accountGasLimits,uint256 preVerificationGas,bytes32 gasFees,bytes paymasterAndData)')),
+            packedOp.sender, packedOp.nonce,
+            keccak256(packedOp.initCode), keccak256(packedOp.callData),
+            packedOp.accountGasLimits, packedOp.preVerificationGas, packedOp.gasFees,
             keccak256(packedOp.paymasterAndData)
         ]
     );
@@ -47,8 +47,17 @@ export function getUserOpHash(op: UserOperation | PackedUserOperation, entryPoin
         packedOp = op as PackedUserOperation;
     }
     const userOpHash = keccak256(packUserOp(packedOp));
-    const enc = new ethers.AbiCoder().encode(
-        ['bytes32', 'address', 'uint256'],
-        [userOpHash, entryPoint, chainId])
-    return keccak256(enc)
+    const hashedName = keccak256(ethers.toUtf8Bytes("ERC4337"));
+    const hashedVersion = keccak256(ethers.toUtf8Bytes("1"));
+    const typeHash = keccak256(ethers.toUtf8Bytes("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"));
+
+    const abiCoder = ethers.AbiCoder.defaultAbiCoder();
+    const types = ["bytes32", "bytes32", "bytes32", "uint256", "address"];
+    const values = [typeHash, hashedName, hashedVersion, chainId, entryPoint];
+    const domainSeparator = ethers.keccak256(abiCoder.encode(types, values));
+
+    const typedData = ethers.solidityPacked(["bytes", "bytes32", "bytes32"], ["0x1901", domainSeparator, userOpHash]);
+    const typedDataHash = ethers.keccak256(typedData);
+
+    return typedDataHash;
 }


### PR DESCRIPTION
Refactored getUserOpHash to compute the hash using an EIP-712 domain separator for improved standards compliance. Updated test values to match the new hashing logic and adjusted packUserOp encoding to include a type hash.